### PR TITLE
feat: tokens atribuição composta e módulo

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -32,6 +32,12 @@ NUM         {DIGITO}+(\.{DIGITO}+)?
 "float"     { return FLOAT; }
 "char"      { return CHAR; }
 
+"+="        { return MAIS_ATRIB; }
+"-="        { return MENOS_ATRIB; }
+"*="        { return MULT_ATRIB; }
+"/="        { return DIV_ATRIB; }
+"%="        { return MOD_ATRIB; }
+
 ";"         { return PONTO_VIRGULA; }
 "/"         { return DIV; }
 "="         { return ATRIB; }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -32,8 +32,8 @@ NUM         {DIGITO}+(\.{DIGITO}+)?
 "float"     { return FLOAT; }
 "char"      { return CHAR; }
 
-"+="        { return MAIS_ATRIB; }
-"-="        { return MENOS_ATRIB; }
+"+="        { return SOMA_ATRIB; }
+"-="        { return SUB_ATRIB; }
 "*="        { return MULT_ATRIB; }
 "/="        { return DIV_ATRIB; }
 "%="        { return MOD_ATRIB; }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,6 +38,7 @@ NUM         {DIGITO}+(\.{DIGITO}+)?
 "+"         { return SOMA; }
 "-"         { return SUB; }
 "*"         { return MULT; }
+"%"         { return MOD; }
 
 {NUM}       { 
                 yylval.val = atof(yytext); 


### PR DESCRIPTION
## Descrição

Este PR adiciona suporte, no **analisador léxico**, para operadores de **atribuição composta** e para o operador de **módulo (`%`)**.

Closes #11 

## Funcionalidades adicionadas

- Reconhecimento dos operadores de atribuição composta:
  - `+=`
  - `-=`
  - `*=`
  - `/=`
  - `%=`  
- Reconhecimento do operador:
  - `%` (módulo)

## Alterações realizadas

- Atualização das regras do analisador léxico para identificar os novos padrões