### PR TITLE
Feat/regras escopo local global

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -54,7 +54,7 @@ void print_indent(void) {
 
 /* 3. AGORA OS %type (Pois o Bison já conhece os tokens acima) */
 %type <str> tipo parametro parametros argumentos
-%type <node> program funcao bloco lista_comandos comando declaracao atribuicao selecao retorno expressao definicao_struct elemento_programa chamada_funcao
+%type <node> program funcao bloco bloco_da_funcao lista_comandos comando declaracao atribuicao selecao retorno expressao definicao_struct elemento_programa chamada_funcao
 %type <node> for_init for_cond for_incr
 
 /* Precedências */
@@ -77,11 +77,11 @@ void print_indent(void) {
 elemento_programa:
       funcao { $$ = $1; }
     | MAIN APARENTESE FPARENTESE bloco { 
-          inserir("main", "int", 0, yylineno); 
+          inserir("main", "int", yylineno); 
           $$ = create_func_node("int", "main", "", $4); 
       }
     | tipo MAIN APARENTESE FPARENTESE bloco { 
-          inserir("main", $1, 0, yylineno); 
+          inserir("main", $1, yylineno); 
           $$ = create_func_node($1, "main", "", $5); 
       }
 ;
@@ -98,23 +98,25 @@ program:
 ;
 
 funcao:
-    modificadores tipo ID APARENTESE parametros FPARENTESE {
-        inserir($3, $2, 0, yylineno); 
-    } 
-    bloco {
-        $$ = create_func_node($2, $3, $5, $8); 
+    modificadores tipo ID APARENTESE { entrar_escopo(); } parametros FPARENTESE bloco_da_funcao {
+        $$ = create_func_node($2, $3, $6, $8); 
+    }
+;
+
+bloco_da_funcao:
+    ACHAVE lista_comandos FCHAVE {
+        if (indent == 1) {
+            fprintf(stderr, "\n=== TABELA DE SÍMBOLOS DA FUNÇÃO ===\n");
+            imprimir_tabela();
+        }
+        sair_escopo();
+        $$ = create_block_node($2);
     }
 ;
 
 bloco:
-    ACHAVE { indent++; } lista_comandos FCHAVE { 
-        if (indent == 1) {
-            fprintf(stderr, "\n=== TABELA DE SÍMBOLOS COMPLETA ===\n");
-            imprimir_tabela();
-        }
-        remover_escopo(indent); 
-        indent--; 
-        
+    ACHAVE { entrar_escopo(); } lista_comandos FCHAVE { 
+        sair_escopo(); 
         $$ = create_block_node($3);
     }
 ;
@@ -174,7 +176,7 @@ parametros:
 
 parametro:
     tipo ID {
-        inserir($2, $1, indent + 1, yylineno);
+        inserir($2, $1, yylineno);
         $$ = strdup($2);
     }
 ;
@@ -188,11 +190,11 @@ modificadores:
 
 declaracao:
       modificadores tipo ID PONTO_VIRGULA {
-          inserir($3, $2, indent, yylineno);
+          inserir($3, $2, yylineno); 
           $$ = create_decl_node($2, $3, NULL);
       }
     | modificadores tipo ID ATRIB expressao PONTO_VIRGULA { 
-          inserir($3, $2, indent, yylineno);
+          inserir($3, $2, yylineno); 
           $$ = create_decl_node($2, $3, $5);
       }
 ;
@@ -301,11 +303,11 @@ argumentos:
 for_init:
       /* vazio */ { $$ = NULL; }
     | tipo ID {
-          inserir($2, $1, indent, yylineno);
+          inserir($2, $1, yylineno);
           $$ = create_decl_node($1, $2, NULL);
       }
     | tipo ID ATRIB expressao {
-          inserir($2, $1, indent, yylineno);
+          inserir($2, $1, yylineno);
           $$ = create_decl_node($1, $2, $4);
       }
     | ID ATRIB expressao {

--- a/src/parser.y
+++ b/src/parser.y
@@ -25,7 +25,7 @@ void print_indent(void) {
     #include "ast/ast.h"
 }
 
-%type <str> expressao lista_ids tipo comentario parametros parametro
+
 
 %token INT FLOAT CHAR DOUBLE VOID
 %token <str> COMMENT_LINE COMMENT_BLOCK
@@ -54,8 +54,7 @@ void print_indent(void) {
 /* Tokens com valor de string */
 %token <str> STR_LITERAL CHAR_LITERAL NUM ID
 
-/* 3. AGORA OS %type (Pois o Bison já conhece os tokens acima) */
-%type <str> tipo parametro parametros argumentos
+%type <str> comentario argumentos tipo parametro parametros
 %type <node> program funcao bloco bloco_da_funcao lista_comandos comando declaracao atribuicao selecao retorno expressao definicao_struct elemento_programa chamada_funcao
 %type <node> for_init for_cond for_incr
 
@@ -115,7 +114,6 @@ bloco_da_funcao:
         sair_escopo();
         $$ = create_block_node($2);
     }
-    bloco
     
 ;
 
@@ -176,43 +174,6 @@ tipo:
     }
 ;
 
-lista_ids:
-      ID {
-
-        if (buscar($1) != NULL) {
-            fprintf(stderr,
-                "Erro Semantico na linha %d: Variavel '%s' ja declarada.\n",
-                yylineno,
-                $1);
-            exit(1);
-        }
-
-        inserir($1, "desconhecido", indent, yylineno);
-
-        print_indent();
-        printf("%s = None\n", $1);
-
-        $$ = strdup($1);
-      }
-
-    | lista_ids VIRGULA ID {
-
-        if (buscar($3) != NULL) {
-            fprintf(stderr,
-                "Erro Semantico na linha %d: Variavel '%s' ja declarada.\n",
-                yylineno,
-                $3);
-            exit(1);
-        }
-
-        inserir($3, "desconhecido", indent, yylineno);
-
-        print_indent();
-        printf("%s = None\n", $3);
-
-        $$ = $1;
-      }
-;
 
 parametros:
     { $$ = strdup(""); }
@@ -302,47 +263,6 @@ atribuicao:
     | ID DEC PONTO_VIRGULA {
         if (buscar($1) == NULL) { fprintf(stderr, "Erro Semantico...\n"); exit(1); }
         $$ = create_assign_node($1, "-=", create_literal_node("1"));
-    }
-;
-
-repeticao:
-    FOR APARENTESE
-    ID ATRIB expressao PONTO_VIRGULA
-    expressao PONTO_VIRGULA
-    ID INC
-    FPARENTESE
-    {
-
-        char var[100];
-        char operador[10];
-        char limite[100];
-
-        if (buscar($3) == NULL) {
-            fprintf(stderr,
-                "Erro Semantico na linha %d: Variavel '%s' nao declarada.\n",
-                yylineno,
-                $3);
-            exit(1);
-        }
-
-        if (strcmp($3, $9) != 0) {
-            fprintf(stderr,
-                "Erro Semantico na linha %d: Variaveis do for inconsistentes.\n",
-                yylineno);
-            exit(1);
-        }
-
-        sscanf($7, "%99s %9s %99s", var, operador, limite);
-
-        print_indent();
-
-        printf("for %s in range(%s, %s):\n", $3, $5, limite);
-
-        indent++;
-    }
-    comando
-    {
-        indent--;
     }
 ;
 

--- a/src/tabela.c
+++ b/src/tabela.c
@@ -3,50 +3,121 @@
 #include <string.h>
 #include "tabela.h"
 
-Simbolo *tabela_simbolos = NULL;
+// Esta variável global agora controla o escopo que está ativo no momento
+Escopo *escopo_atual = NULL;
 
-void inserir(char *nome, char *tipo, int escopo, int linha) {
-    Simbolo *novo = (Simbolo*) malloc(sizeof(Simbolo));
-    novo->nome = strdup(nome);
-    novo->tipo = strdup(tipo);
-    novo->escopo = escopo;
-    novo->linha = linha;
+// Cria um novo escopo (chamado ao abrir uma chave '{')
+void entrar_escopo() {
+    Escopo *novo_escopo = (Escopo*) malloc(sizeof(Escopo));
+    novo_escopo->lista_simbolos = NULL;
     
-    novo->proximo = tabela_simbolos;
-    tabela_simbolos = novo;
+    // O pai do novo escopo é o escopo que estava ativo até agora
+    novo_escopo->escopo_pai = escopo_atual;
+    
+    // O novo escopo se torna o escopo atual
+    escopo_atual = novo_escopo;
 }
 
-Simbolo* buscar(char *nome) {
-    Simbolo *atual = tabela_simbolos;
+// Destrói o escopo atual e volta para o pai (chamado ao fechar uma chave '}')
+void sair_escopo() {
+    if (escopo_atual == NULL) return;
+
+    Escopo *escopo_antigo = escopo_atual;
+    
+    // Primeiro, liberamos todos os símbolos que foram criados neste escopo
+    Simbolo *atual = escopo_antigo->lista_simbolos;
     while (atual != NULL) {
-        if (strcmp(atual->nome, nome) == 0) {
-            return atual; 
-        }
+        Simbolo *aux = atual;
         atual = atual->proximo;
-    }
-    return NULL; 
-}
-
-void remover_escopo(int escopo) {
-    while (tabela_simbolos != NULL && tabela_simbolos->escopo == escopo) {
-        Simbolo *aux = tabela_simbolos;
-        tabela_simbolos = tabela_simbolos->proximo;
         free(aux->nome);
         free(aux->tipo);
         free(aux);
     }
+    
+    // O escopo atual volta a ser o escopo pai
+    escopo_atual = escopo_antigo->escopo_pai;
+    
+    // Liberamos a estrutura do escopo em si
+    free(escopo_antigo);
 }
 
-void imprimir_tabela() {
-    Simbolo *atual = tabela_simbolos;
-    fprintf(stderr, "\n--- CONTEÚDO DA TABELA DE SÍMBOLOS ---\n");
-    fprintf(stderr, "%-10s | %-10s | %-7s | %-5s\n", "NOME", "TIPO", "ESCOPO", "LINHA");
-    fprintf(stderr, "--------------------------------------------\n");
+// Insere um símbolo APENAS no escopo que está ativo no momento
+void inserir(char *nome, char *tipo, int linha) {
+    // Se por acaso não houver escopo ativo (ex: variáveis globais antes de qualquer função),
+    // criamos o escopo global automaticamente.
+    if (escopo_atual == NULL) {
+        entrar_escopo();
+    }
+
+    // Opcional: Validar se a variável já existe NO MESMO ESCOPO (Erro de redeclaração)
+    if (buscar_local(nome) != NULL) {
+        fprintf(stderr, "Erro Semantico na linha %d: Redeclaracao de '%s' no mesmo escopo.\n", linha, nome);
+        exit(1);
+    }
+
+    Simbolo *novo = (Simbolo*) malloc(sizeof(Simbolo));
+    novo->nome = strdup(nome);
+    novo->tipo = strdup(tipo);
+    novo->linha = linha;
     
+    // Insere no topo da lista de símbolos do escopo atual
+    novo->proximo = escopo_atual->lista_simbolos;
+    escopo_atual->lista_simbolos = novo;
+}
+
+// Busca um símbolo do escopo atual subindo até o escopo global (Regra de Escopo do C)
+Simbolo* buscar(char *nome) {
+    Escopo *escopo_varredura = escopo_atual;
+    
+    // Navega subindo pelos escopos pais
+    while (escopo_varredura != NULL) {
+        Simbolo *atual = escopo_varredura->lista_simbolos;
+        
+        // Procura na lista de símbolos do escopo que está sendo analisado no laço
+        while (atual != NULL) {
+            if (strcmp(atual->nome, nome) == 0) {
+                return atual; // Achou! Pode ser local ou de um pai/global
+            }
+            atual = atual->proximo;
+        }
+        
+        // Se não achou neste escopo, sobe para o pai
+        escopo_varredura = escopo_varredura->escopo_pai;
+    }
+    
+    return NULL; // Não achou em escopo nenhum (variável não declarada)
+}
+
+// Busca uma variável APENAS no escopo atual (útil para detectar redeclarações legítimas)
+Simbolo* buscar_local(char *nome) {
+    if (escopo_atual == NULL) return NULL;
+    
+    Simbolo *atual = escopo_atual->lista_simbolos;
     while (atual != NULL) {
-        fprintf(stderr, "%-10s | %-10s | %-7d | %-5d\n", 
-               atual->nome, atual->tipo, atual->escopo, atual->linha);
+        if (strcmp(atual->nome, nome) == 0) {
+            return atual;
+        }
         atual = atual->proximo;
     }
-    fprintf(stderr, "--------------------------------------------\n\n");
+    return NULL;
+}
+
+// Imprime os símbolos pertencentes APENAS ao escopo atual
+void imprimir_tabela() {
+    if (escopo_atual == NULL) {
+        fprintf(stderr, "\n--- TABELA DE SÍMBOLOS VAZIA (NENHUM ESCOPO ATIVO) ---\n");
+        return;
+    }
+    
+    Simbolo *atual = escopo_atual->lista_simbolos;
+    fprintf(stderr, "\n--- CONTEÚDO DO ESCOPO ATUAL ---\n");
+    fprintf(stderr, "%-15s | %-15s | %-5s\n", "NOME", "TIPO", "LINHA");
+    fprintf(stderr, "--------------------------------------------------\n");
+    
+    while (atual != NULL) {
+        fprintf(stderr, "%-15s | %-15s | %-5d\n", 
+               atual->nome, atual->tipo, atual->linha);
+        atual = atual->proximo;
+    }
+    fprintf(stderr, "--------------------------------------------------\n\n");
 }

--- a/src/tabela.h
+++ b/src/tabela.h
@@ -1,12 +1,33 @@
+#ifndef TABELA_H
+#define TABELA_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Estrutura de um símbolo individual
 typedef struct Simbolo {
     char *nome;
     char *tipo;      
-    int escopo;     
     int linha;       
     struct Simbolo *proximo;
 } Simbolo;
 
-void inserir(char *nome, char *tipo, int escopo, int linha);
+// Estrutura de um Escopo (uma tabela local que aponta para o seu escopo pai)
+typedef struct Escopo {
+    Simbolo *lista_simbolos;     // Lista ligada de símbolos DESTE escopo
+    struct Escopo *escopo_pai;   // Ponteiro para o escopo que engloba este
+} Escopo;
+
+// Funções de gerenciamento de escopo
+void entrar_escopo();
+void sair_escopo();
+
+// Funções de manipulação de símbolos
+void inserir(char *nome, char *tipo, int linha);
 Simbolo* buscar(char *nome);
-void remover_escopo(int escopo);
+Simbolo* buscar_local(char *nome); // Auxiliar para evitar redeclaração no mesmo bloco
+
 void imprimir_tabela();
+
+#endif

--- a/tests/teste.c
+++ b/tests/teste.c
@@ -3,12 +3,11 @@ static int testar_escopos(int parametro_a) {
     x = 5;
     
     {
-        char x; // Shadowing: Este 'x' esconde o 'x' de cima
+        char x; 
         x = 'G';
         int interno_bloco;
         interno_bloco = 42;
-    } // 'interno_bloco' e o 'char x' morrem aqui!
-    
+    } 
     parametro_a = parametro_a + 1;
 }
 
@@ -20,8 +19,8 @@ int main() {
         if (i == 2 && !parado) {
             continue; 
         }
-        int inverso;
-        inverso = -i;
+        int inverso = -i;
+        
     }
     return 0;
 }

--- a/tests/teste.c
+++ b/tests/teste.c
@@ -1,3 +1,17 @@
+static int testar_escopos(int parametro_a) {
+    int x;
+    x = 5;
+    
+    {
+        char x; // Shadowing: Este 'x' esconde o 'x' de cima
+        x = 'G';
+        int interno_bloco;
+        interno_bloco = 42;
+    } // 'interno_bloco' e o 'char x' morrem aqui!
+    
+    parametro_a = parametro_a + 1;
+}
+
 int main() {
     int i = 0;
     int parado = 0;
@@ -6,7 +20,8 @@ int main() {
         if (i == 2 && !parado) {
             continue; 
         }
-        int inverso = -i;
+        int inverso;
+        inverso = -i;
     }
     return 0;
 }


### PR DESCRIPTION
## Descrição
Este Pull Request implementa o sistema de múltiplos escopos locais através de uma estrutura de pilha de tabelas de símbolos encadeadas. Com isso, o compilador passa a isolar corretamente variáveis declaradas dentro de funções, laços `for` e blocos aninhados (`{ ... }`), além de realizar a verificação semântica essencial para impedir e acusar o uso de variáveis que não foram declaradas.

---

## Vínculo com Issue
* Closes #55 

## Funcionalidades Implementadas

* **Pilha de Escopos Dinâmica**: Criação e destruição de escopos locais ao abrir e fechar chaves.
* **Mecanismo de Shadowing**: Suporte para que uma variável interna "esconda" uma externa de mesmo nome temporariamente.
* **Verificação Semântica Ativa**: Bloqueio imediato com erro caso o código tente ler ou atribuir um valor a uma variável inexistente no escopo atual ou nos escopos pais.

---

## Alterações Realizadas

### Lexer
* Nenhuma alteração direta nesta etapa.
### Parser
* Integração das chamadas semânticas `entrar_escopo()` e `sair_escopo()` nas regras de `bloco` e `bloco_da_funcao`.
* Limpeza e correção de conflitos de tipos (`%type`) no topo do arquivo após o merge com a branch `main`.
* Ajuste na chamada da função `inserir()` nas regras de declaração para sincronizar com a nova assinatura da tabela.

### Semântica
* **`src/tabela.h` / `src/tabela.c`**: Reformulados por completo. A tabela de símbolos global estática foi substituída por uma lógica de ponteiros encadeados que representam a pilha de escopos ativa.
* A função `buscar()` foi atualizada para fazer uma varredura reversa (do escopo mais interno para o mais externo) para validar a existência da variável.
* Injeção de blocos de validação (`if (buscar($1) == NULL) { ... exit(1); }`) em todas as regras de atribuição e uso de variáveis no `parser.y`.

### Testes
* **`tests/teste.c`**: Atualizado para incluir uma função estática de teste de escopo com variáveis locais, mascaramento (*shadowing*) e laço `for`. 
* Adicionados cenários comentados para forçar erros semânticos de variáveis fora de escopo.

---

## Resultado

O compilador agora valida o escopo perfeitamente. O script `./tests/run_tests.sh` executa com sucesso no caminho feliz e barra o programa com mensagens claras nos cenários de erro.

### Evidências (Prints dos Testes)

1. **Caminho Feliz (Sucesso com múltiplos escopos locais):**
  <img width="498" height="902" alt="image" src="https://github.com/user-attachments/assets/fc758800-99cf-4af1-bde6-54376381c078" />

2. **Erro Semântico - Variável do laço `for` morrendo fora dele (`inverso = 10`):**

| Teste | Execução no terminal|
| :---: | :---: |
| <img width="386" height="560" alt="image" src="https://github.com/user-attachments/assets/29f2cdcb-eb9b-43a3-96d4-35a3960d2969" /> |  <img width="476" height="102" alt="image" src="https://github.com/user-attachments/assets/4f31fb63-7024-4441-9fd1-661c4b98313c" /> |