### PR TITLE
feat: implementa arrays e ponteiros

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -18,6 +18,7 @@ ASTNode* allocate_node(NodeType type) {
     node->type = type;
     node->value = NULL;
     node->var_type = NULL;
+    node->array_size = 0;
     node->left = NULL;
     node->right = NULL;
     node->next = NULL;
@@ -97,6 +98,57 @@ ASTNode* create_program_node(ASTNode* child, ASTNode* next) {
     ASTNode* node = allocate_node(NODE_PROGRAM);
     node->left = child;
     node->next = next;
+    return node;
+}
+
+ASTNode* create_array_decl_node(char* var_type, char* name, int size, ASTNode* init) {
+    ASTNode* node    = allocate_node(NODE_ARRAY_DECL);
+    node->var_type   = strdup(var_type);
+    node->value      = strdup(name);
+    node->array_size = size;
+    node->left       = init;
+    return node;
+}
+
+ASTNode* create_array_access_node(char* name, ASTNode* index) {
+    ASTNode* node = allocate_node(NODE_ARRAY_ACCESS);
+    node->value   = strdup(name);
+    node->left    = index;
+    return node;
+}
+
+ASTNode* create_array_assign_node(char* name, ASTNode* index, ASTNode* expr) {
+    ASTNode* node = allocate_node(NODE_ARRAY_ASSIGN);
+    node->value   = strdup(name);
+    node->left    = index;
+    node->right   = expr;
+    return node;
+}
+
+ASTNode* create_pointer_decl_node(char* var_type, char* name, ASTNode* init) {
+    ASTNode* node  = allocate_node(NODE_PTR_DECL);
+    node->var_type = strdup(var_type);
+    node->value    = strdup(name);
+    node->left     = init;
+    return node;
+}
+
+ASTNode* create_pointer_assign_node(ASTNode* ptr_expr, ASTNode* val_expr) {
+    ASTNode* node = allocate_node(NODE_PTR_ASSIGN);
+    node->left    = ptr_expr;
+    node->right   = val_expr;
+    return node;
+}
+
+ASTNode* create_address_node(ASTNode* operand) {
+    ASTNode* node = allocate_node(NODE_ADDRESS);
+    node->left    = operand;
+    return node;
+}
+
+ASTNode* create_deref_node(ASTNode* operand) {
+    ASTNode* node = allocate_node(NODE_DEREF);
+    node->left    = operand;
     return node;
 }
 
@@ -268,6 +320,74 @@ void generate_python(ASTNode* node, int indent_level) {
             }
             break;
         }
+
+        case NODE_ARRAY_DECL:
+            print_python_indent(indent_level);
+            if (!node->left) {
+                printf("%s = [None] * %d\n", node->value, node->array_size);
+            } else if (node->left->next == NULL && node->left->type != NODE_LITERAL
+                       && node->left->type != NODE_ID) {
+                printf("%s = ", node->value);
+                generate_python(node->left, 0);
+                printf("\n");
+            } else {
+                printf("%s = [", node->value);
+                ASTNode* elem = node->left;
+                while (elem) {
+                    generate_python(elem, 0);
+                    if (elem->next) printf(", ");
+                    elem = elem->next;
+                }
+                printf("]\n");
+            }
+            break;
+        
+        case NODE_ARRAY_ACCESS:
+            printf("%s[", node->value);
+            generate_python(node->left, 0);
+            printf("]");
+            break;   
+
+        case NODE_ARRAY_ASSIGN:
+            print_python_indent(indent_level);
+            printf("%s[", node->value);
+            generate_python(node->left, 0);
+            printf("] = ");
+            generate_python(node->right, 0);
+            printf("\n");
+            break;
+        
+        case NODE_PTR_DECL:
+            print_python_indent(indent_level);
+            if (!node->left) {
+                printf("%s = None  # ponteiro %s*\n", node->value, node->var_type);
+            } else {
+                printf("%s = ", node->value);
+                generate_python(node->left, 0);
+                printf("  # ponteiro %s*\n", node->var_type);
+            }
+            break;
+
+        case NODE_PTR_ASSIGN:
+            print_python_indent(indent_level);
+            if (node->left && node->left->type == NODE_ID) {
+                printf("%s[0] = ", node->left->value);
+            } else {
+                generate_python(node->left, 0);
+                printf("[0] = ");
+            }
+            generate_python(node->right, 0);
+            printf("\n");
+            break;
+
+        case NODE_ADDRESS:
+            generate_python(node->left, 0);
+            break;
+
+        case NODE_DEREF:
+            generate_python(node->left, 0);
+            printf("[0]");
+            break;
     }
 } 
 
@@ -288,6 +408,13 @@ const char* get_node_type_name(NodeType type) {
         case NODE_CONTINUE: return "CONTINUE";
         case NODE_FOR:      return "FOR_LOOP";
         case NODE_UNARY_OP: return "UNARY_OP";
+        case NODE_ARRAY_DECL:   return "ARRAY_DECL";
+        case NODE_ARRAY_ACCESS: return "ARRAY_ACCESS";
+        case NODE_ARRAY_ASSIGN: return "ARRAY_ASSIGN";
+        case NODE_PTR_DECL:     return "PTR_DECL";
+        case NODE_PTR_ASSIGN:   return "PTR_ASSIGN";
+        case NODE_ADDRESS:      return "ADDRESS";
+        case NODE_DEREF:        return "DEREF";
         default:            return "UNKNOWN";
     }
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -20,7 +20,14 @@ typedef enum {
     NODE_BREAK,
     NODE_CONTINUE,
     NODE_FOR,
-    NODE_UNARY_OP
+    NODE_UNARY_OP,
+    NODE_ARRAY_DECL,    
+    NODE_ARRAY_ACCESS,
+    NODE_ARRAY_ASSIGN,
+    NODE_PTR_DECL,
+    NODE_PTR_ASSIGN,
+    NODE_ADDRESS,
+    NODE_DEREF     
 } NodeType;
 
 typedef struct ASTNode {
@@ -28,6 +35,7 @@ typedef struct ASTNode {
     
     char* value;       
     char* var_type;    
+    int   array_size;
 
     struct ASTNode* left;
     struct ASTNode* right;
@@ -49,7 +57,13 @@ ASTNode* create_break_node(void);
 ASTNode* create_continue_node(void);
 ASTNode* create_for_node(ASTNode* init, ASTNode* cond, ASTNode* incr, ASTNode* body);
 ASTNode* create_unary_op_node(char* op, ASTNode* expr);
-
+ASTNode* create_array_decl_node(char* var_type, char* name, int size, ASTNode* init);
+ASTNode* create_array_access_node(char* name, ASTNode* index);
+ASTNode* create_array_assign_node(char* name, ASTNode* index, ASTNode* expr);
+ASTNode* create_pointer_decl_node(char* var_type, char* name, ASTNode* init);
+ASTNode* create_pointer_assign_node(ASTNode* ptr_expr, ASTNode* val_expr);
+ASTNode* create_address_node(ASTNode* operand);
+ASTNode* create_deref_node(ASTNode* operand);
 void generate_python(ASTNode* node, int indent_level);
 void print_ast(ASTNode* node, int level);
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -89,6 +89,7 @@ ESCAPE      \\[ntr0"'\\]
 "*"         { return MULT; }
 "/"         { return DIV; }
 "%"         { return MOD; }
+"&"         { return BIT_AND; }
 
 \"([^\"\\\n]|\\.)*\n {
     yylineno--;

--- a/src/parser.y
+++ b/src/parser.y
@@ -54,9 +54,12 @@ void print_indent(void) {
 /* Tokens com valor de string */
 %token <str> STR_LITERAL CHAR_LITERAL NUM ID
 
+%token BIT_AND
+
 %type <str> comentario argumentos tipo parametro parametros
 %type <node> program funcao bloco bloco_da_funcao lista_comandos comando declaracao atribuicao selecao retorno expressao definicao_struct elemento_programa chamada_funcao
 %type <node> for_init for_cond for_incr
+%type <node> lista_init declaracao_array acesso_array
 
 /* Precedências */
 %left OR_LOGICO
@@ -66,7 +69,7 @@ void print_indent(void) {
 %left SOMA SUB
 %left MULT DIV MOD
 %right INC DEC 
-%right NOT UMINUS
+%right NOT UMINUS DEREF
 
 
 %nonassoc LOWER_THAN_ELSE
@@ -100,7 +103,10 @@ program:
 ;
 
 funcao:
-    modificadores tipo ID APARENTESE { entrar_escopo(); } parametros FPARENTESE bloco_da_funcao {
+      tipo ID APARENTESE { entrar_escopo(); } parametros FPARENTESE bloco_da_funcao {
+          $$ = create_func_node($1, $2, $5, $7);
+      }
+    | modificadores tipo ID APARENTESE { entrar_escopo(); } parametros FPARENTESE bloco_da_funcao {
         $$ = create_func_node($2, $3, $6, $8); 
     }
 ;
@@ -193,13 +199,36 @@ modificadores:
 ;
 
 declaracao:
-      modificadores tipo ID PONTO_VIRGULA {
+    tipo ID PONTO_VIRGULA {
+          inserir($2, $1, yylineno);
+          $$ = create_decl_node($1, $2, NULL);
+      }
+    | tipo ID ATRIB expressao PONTO_VIRGULA {
+          inserir($2, $1, yylineno);
+          $$ = create_decl_node($1, $2, $4);
+      }
+      
+    | modificadores tipo ID PONTO_VIRGULA {
           inserir($3, $2, yylineno); 
           $$ = create_decl_node($2, $3, NULL);
       }
     | modificadores tipo ID ATRIB expressao PONTO_VIRGULA { 
           inserir($3, $2, yylineno); 
           $$ = create_decl_node($2, $3, $5);
+      }
+
+    | declaracao_array {
+          $$ = $1;
+      }
+
+    | tipo MULT ID PONTO_VIRGULA {
+        inserir_ponteiro($3, $1, yylineno);
+        $$ = create_pointer_decl_node($1, $3, NULL);
+      }
+
+    | tipo MULT ID ATRIB BIT_AND expressao PONTO_VIRGULA {
+        inserir_ponteiro($3, $1, yylineno);
+        $$ = create_pointer_decl_node($1, $3, create_address_node($6));
       }
 ;
 
@@ -262,6 +291,18 @@ atribuicao:
         if (buscar($1) == NULL) { fprintf(stderr, "Erro Semantico...\n"); exit(1); }
         $$ = create_assign_node($1, "-=", create_literal_node("1"));
     }
+
+    | ID A_COLCHETE expressao F_COLCHETE ATRIB expressao PONTO_VIRGULA {
+            if (buscar($1) == NULL) { fprintf(stderr,"Erro Semantico na linha %d: array '%s' nao declarado.\n", yylineno, $1); exit(1); }
+            $$ = create_array_assign_node( $1, $3, $6);
+    }
+
+    | MULT ID ATRIB expressao PONTO_VIRGULA {
+        Simbolo *s = buscar($2);
+        if (s == NULL) {fprintf(stderr, "Erro Semantico na linha %d: Variavel '%s' nao declarada.\n", yylineno, $2); exit(1);}
+        if (s->categoria != SIM_PONTEIRO) {fprintf(stderr,"Erro Semantico na linha %d: '%s' nao e um ponteiro, nao pode ser desreferenciado.\n", yylineno, $2); exit(1);}
+        $$ = create_pointer_assign_node(create_id_node($2), $4);
+    }
 ;
 
 selecao:
@@ -318,6 +359,9 @@ expressao:
     | APARENTESE expressao FPARENTESE { $$ = $2; }
     | NOT expressao { $$ = create_unary_op_node("!", $2); }
     | SUB expressao %prec UMINUS { $$ = create_unary_op_node("-", $2); }
+    | acesso_array { $$ = $1; }
+    | BIT_AND ID { $$ = create_address_node(create_id_node($2)); }
+    | MULT expressao %prec DEREF { $$ = create_deref_node($2); }
 ;
 
 chamada_funcao:
@@ -367,6 +411,37 @@ for_incr:
     | ID SUB_ATRIB expressao { $$ = create_assign_node($1, "-=", $3); }
     | ID INC { $$ = create_assign_node($1, "+=", create_literal_node("1")); }
     | ID DEC { $$ = create_assign_node($1, "-=", create_literal_node("1")); }
+;
+
+declaracao_array:
+      tipo ID A_COLCHETE NUM F_COLCHETE PONTO_VIRGULA {
+          inserir_array($2, $1, atoi($4), yylineno);
+          $$ = create_array_decl_node($1, $2, atoi($4), NULL);
+      }
+    | tipo ID A_COLCHETE NUM F_COLCHETE ATRIB expressao PONTO_VIRGULA {
+          inserir_array($2, $1, atoi($4), yylineno);
+          $$ = create_array_decl_node($1, $2, atoi($4), $7);
+      }
+    
+    | tipo ID A_COLCHETE NUM F_COLCHETE ATRIB ACHAVE lista_init FCHAVE PONTO_VIRGULA {
+          inserir_array($2, $1, atoi($4), yylineno);
+          $$ = create_array_decl_node($1, $2, atoi($4), $8);
+      }
+;
+
+acesso_array:
+      ID A_COLCHETE expressao F_COLCHETE {
+          if (buscar($1) == NULL) {fprintf(stderr, "Erro Semantico na linha %d: array '%s' nao declarado.\n", yylineno, $1);
+              exit(1);
+          }
+          $$ = create_array_access_node($1,$3);
+      }
+;
+
+lista_init:
+      expressao {$$ = $1;}
+    | lista_init VIRGULA expressao {ASTNode* curr = $1; while (curr->next != NULL) curr = curr->next; curr->next = $3; $$ = $1;
+      }
 ;
 
 %%

--- a/src/tabela.c
+++ b/src/tabela.c
@@ -7,6 +7,8 @@ typedef struct SímboloHistórico {
     char* nome;       
     char* tipo;       
     int linha;
+    TipoSimbolo categoria;
+    int tamanho_array;
     struct SímboloHistórico* proximo;
 } SimboloHistorico;
 
@@ -43,7 +45,7 @@ void sair_escopo() {
     free(escopo_antigo);
 }
 
-void inserir(char* nome, char *tipo, int linha) {
+static void inserir_simbolo(char* nome, char *tipo, TipoSimbolo cat, int tamanho, int linha) {
     
     if (escopo_atual == NULL) {
         entrar_escopo();
@@ -58,6 +60,8 @@ void inserir(char* nome, char *tipo, int linha) {
     novo->nome = strdup(nome);
     novo->tipo = strdup(tipo);
     novo->linha = linha;
+    novo->categoria     = cat;
+    novo->tamanho_array = tamanho;
     novo->proximo = escopo_atual->lista_simbolos;
     escopo_atual->lista_simbolos = novo;
 
@@ -65,6 +69,8 @@ void inserir(char* nome, char *tipo, int linha) {
     novo_historico->nome = strdup(nome); 
     novo_historico->tipo = strdup(tipo);
     novo_historico->linha = linha;
+    novo_historico->categoria     = cat;
+    novo_historico->tamanho_array = tamanho;
     novo_historico->proximo = NULL;
 
     if (historico_inicio == NULL) {
@@ -74,6 +80,18 @@ void inserir(char* nome, char *tipo, int linha) {
         historico_fim->proximo = novo_historico;
         historico_fim = novo_historico;
     }
+}
+
+void inserir(char *nome, char *tipo, int linha) {
+    inserir_simbolo(nome, tipo, SIM_VAR, 0, linha);
+}
+
+void inserir_array(char *nome, char *tipo, int tamanho, int linha) {
+    inserir_simbolo(nome, tipo, SIM_ARRAY, tamanho, linha);
+}
+
+void inserir_ponteiro(char *nome, char *tipo, int linha) {
+    inserir_simbolo(nome, tipo, SIM_PONTEIRO, 0, linha);
 }
 
 Simbolo* buscar(char *nome) {
@@ -110,6 +128,19 @@ Simbolo* buscar_local(char *nome) {
     return NULL;
 }
 
+static const char *categoria_str(TipoSimbolo cat, int tamanho, char *buf, int buf_sz) {
+    switch (cat) {
+        case SIM_VAR:     return "variavel"; 
+        case SIM_PONTEIRO: return "ponteiro"; 
+        case SIM_ARRAY: {
+            snprintf(buf, buf_sz, "array[%d]", tamanho);
+            return buf;
+        }
+        default: snprintf(buf, buf_sz, "?"); return buf;
+    }
+    return "?";
+}
+
 void imprimir_tabela() {
     if (escopo_atual == NULL) {
         fprintf(stderr, "\n--- TABELA DE SÍMBOLOS VAZIA (NENHUM ESCOPO ATIVO) ---\n");
@@ -118,12 +149,14 @@ void imprimir_tabela() {
     
     Simbolo *atual = escopo_atual->lista_simbolos;
     fprintf(stderr, "\n--- CONTEÚDO DO ESCOPO ATUAL ---\n");
-    fprintf(stderr, "%-15s | %-15s | %-5s\n", "NOME", "TIPO", "LINHA");
+    fprintf(stderr, "%-15s | %-15s | %-12s | %-5s\n", "NOME", "TIPO", "CATEGORIA", "LINHA");
     fprintf(stderr, "--------------------------------------------------\n");
     
     while (atual != NULL) {
-        fprintf(stderr, "%-15s | %-15s | %-5d\n", 
-               atual->nome, atual->tipo, atual->linha);
+        char cat_buf[32];
+        categoria_str(atual->categoria, atual->tamanho_array, cat_buf, sizeof(cat_buf));
+        fprintf(stderr, "%-15s | %-15s | %-12s | %-5d\n", 
+               atual->nome, atual->tipo,cat_buf, atual->linha);
         atual = atual->proximo;
     }
     fprintf(stderr, "--------------------------------------------------\n\n");
@@ -135,7 +168,7 @@ void imprimir_historico_completo() {
     fprintf(stderr, "\n==================================================\n");
     fprintf(stderr, "     HISTÓRICO DE TODOS OS SÍMBOLOS PROCESSADOS   \n");
     fprintf(stderr, "==================================================\n");
-    fprintf(stderr, "%-20s | %-15s | %-5s\n", "NOME", "TIPO", "LINHA");
+    fprintf(stderr, "%-20s | %-15s | %-12s | %-5s\n", "NOME", "TIPO", "CATEGORIA", "LINHA");
     fprintf(stderr, "--------------------------------------------------\n");
     
     if (atual == NULL) {
@@ -143,7 +176,10 @@ void imprimir_historico_completo() {
     }
 
     while (atual != NULL) {
-        fprintf(stderr, "%-20s | %-15s | %-5d\n", atual->nome, atual->tipo, atual->linha);
+        char cat_buf[32];
+        categoria_str(atual->categoria, atual->tamanho_array, cat_buf, sizeof(cat_buf));
+        fprintf(stderr, "%-20s | %-15s | %-12s | %-5d\n", 
+               atual->nome, atual->tipo, cat_buf, atual->linha);
         atual = atual->proximo;
     }
     

--- a/src/tabela.h
+++ b/src/tabela.h
@@ -5,10 +5,18 @@
 #include <stdlib.h>
 #include <string.h>
 
+typedef enum {
+    SIM_VAR,
+    SIM_ARRAY,
+    SIM_PONTEIRO
+} TipoSimbolo;
 typedef struct Simbolo {
     char *nome;
     char *tipo;      
-    int linha;       
+    int linha;   
+    TipoSimbolo  categoria;
+    int tamanho_array;
+
     struct Simbolo *proximo;
 } Simbolo;
 
@@ -21,6 +29,8 @@ void entrar_escopo();
 void sair_escopo();
 
 void inserir(char *nome, char *tipo, int linha);
+void inserir_array(char *nome, char *tipo, int tamanho, int linha);
+void inserir_ponteiro(char *nome, char *tipo, int linha);
 Simbolo* buscar(char *nome);
 Simbolo* buscar_local(char *nome); 
 


### PR DESCRIPTION
## Descrição
Este Pull Request implementa o suporte a arrays e ponteiros no compilador C→Python, cobrindo as três camadas do pipeline: parser (análise sintática e semântica), tabela de símbolos e geração de AST com tradução para Python.

---

## Vínculo com Issue
* Closes #58 
* Closes #57 

---

## Funcionalidades Implementadas

* **Declaração e inicialização de arrays**: suporte a `int v[N]`, `int v[N] = expr` e `int v[N] = {e1, e2, …}`.
* **Acesso e atribuição em arrays**: `v[i]` como expressão e `v[i] = expr` como comando.
* **Declaração de ponteiros**: suporte a `int *p` e `int *p = &x`.
* **Atribuição via desreferência**: `*p = expr` com validação semântica de categoria.
* **Operadores de endereço e desreferência**: `&x` e `*expr` como expressões.
* **Verificação semântica de ponteiros**: o compilador rejeita `*x = expr` quando `x` não foi declarado como ponteiro (`SIM_PONTEIRO`).
* **Correção de conflitos shift/reduce**: a regra `modificadores` foi refatorada para `modificador` (sem produção vazia)
* **Correção da tabela de símbolos**: bug `sizeof(buf)` em `categoria_str` corrigido; `default` aninhado incorretamente dentro de `case SIM_ARRAY` reestruturado.
* **Remoção de `static` no header**: `inserir_simbolo` removida de `tabela.h` (função interna de `tabela.c`).

---

## Alterações Realizadas

### Lexer

### Novos tokens reconhecidos

| Símbolo | Token |
|----------|--------|
| `&` | `BIT_AND` |

### Objetivo
Permitir o reconhecimento léxico do operador de endereço utilizado em expressões de ponteiros:

```c
&a
```

### Parser 
* Adicionadas regras de declaração: `tipo MULT ID`, `tipo MULT ID ATRIB BIT_AND expressao`.
* Adicionadas regras de atribuição: `ID A_COLCHETE expressao F_COLCHETE ATRIB expressao`, `MULT ID ATRIB expressao`.
* Adicionadas regras de expressão: `acesso_array`, `BIT_AND ID`, `MULT expressao`.
* Adicionada regra `declaracao_array` com três formas (sem init, com expressão, com lista `{}`).
* Adicionada regra `acesso_array`.
* Adicionada regra `lista_init` para listas de inicialização encadeadas.
* Regra `modificadores` substituída por `modificador` (sem produção vazia) — conflitos shift/reduce eliminados.
* Validação semântica em `MULT ID ATRIB expressao`: verifica declaração e categoria `SIM_PONTEIRO`.
* Correção em `BIT_AND ID`: `$2` envolvido em `create_id_node` antes de passar para `create_address_node`.
### Semântica 
* `inserir_ponteiro()` adicionada — registra símbolo com categoria `SIM_PONTEIRO`.
* `inserir_array()` — registra símbolo com categoria `SIM_ARRAY` e `tamanho_array`.
* `categoria_str()` corrigida: `sizeof(buf)` substituído por `buf_sz`; estrutura do `switch` reestruturada.
* Declaração `static void inserir_simbolo` removida do header.
### AST 
* Campo `int array_size` adicionado à struct `ASTNode`.
* 7 novos tipos de nó adicionados ao enum `NodeType`:
  * `NODE_ARRAY_DECL`, `NODE_ARRAY_ACCESS`, `NODE_ARRAY_ASSIGN`
  * `NODE_PTR_DECL`, `NODE_PTR_ASSIGN`, `NODE_ADDRESS`, `NODE_DEREF`
* Construtores implementados: `create_array_decl_node`, `create_array_access_node`, `create_array_assign_node`, `create_pointer_decl_node`, `create_pointer_assign_node`, `create_address_node`, `create_deref_node`.
* `generate_python()` estendido com tradução para todos os 7 novos nós:
*
| Nó C | Python gerado |
|---|---|
| `int v[3]` | `v = [None] * 3` |
| `int v[3] = {1,2,3}` | `v = [1, 2, 3]` |
| `v[i]` | `v[i]` |
| `v[i] = e` | `v[i] = e` |
| `int *p` | `p = None  # ponteiro int*` |
| `int *p = &x` | `p = x  # ponteiro int*` |
| `*p = e` | `p[0] = e` |
| `*expr` | `expr[0]` |
| `&x` | `x` |
 
* `print_ast()` e `get_node_type_name()` atualizados com os novos tipos.

### Testes
* Adicionada função `testar_arrays`: declaração com e sem init, acesso com índice literal e variável, list init, acesso em declaração de variável.
* Adicionada função `testar_ponteiros`: declaração sem init, atribuição `p = &a`, desreferência `*p = 99`, leitura `b = *p`, declaração com init `int *q = &b`.
```c
static int testar_escopos(int parametro_a) {
    int x;
    x = 5;
    
    {
        char x; 
        x = 'G';
        int interno_bloco;
        interno_bloco = 42;
    } 
    parametro_a = parametro_a + 1;
}

int testar_arrays(int n) {
    int v[5];
    v[0] = 10;
    v[1] = 20;
    v[2] = v[0] + v[1];

    int soma = 0;
    int i = 0;
    for (i = 0; i < 5; i++) {
        soma += v[i];
    }

    int primos[5] = {2, 3, 5, 7, 11};
    int primeiro = primos[0];

    return soma;
}

int testar_ponteiros(int valor) {
    int a;
    a = valor;

    int *p;
    p = &a;

    *p = 99;

    int b;
    b = *p;

    int *q = &b;

    return b;
}

int main() {
    int i = 0;
    int parado = 0;
    
    for (i = 0; i < 5; i++) {
        if (i == 2 && !parado) {
            continue; 
        }
        int inverso = -i;
    }

    int resultado_array = testar_arrays(5);

    int x;
    x = 42;
    int *px;
    px = &x;
    *px = 100;

    int nums[3] = {1, 2, 3};
    nums[1] = 99;
    int val = nums[1];

    return 0;
}
```


---

## Resultado
O compilador reconhece, valida semanticamente e traduz para Python todas as construções de arrays e ponteiros do subconjunto C implementado. O script `./tests/run_tests.sh` executa com sucesso.

---

### Evidências (Saída dos Testes)
<img width="500" height="600" alt="image" src="https://github.com/user-attachments/assets/e323160f-57f4-4da3-95f0-6c3e7590c7f1" />