### PR TITLE
[Feat]:. Adiciona cobertura de testes com gcov/lcov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 tmp_erros.txt
 .vscode
 tests/saida.py
+coverage_report/

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ CC = gcc
 LEX = flex
 YACC = bison
 CFLAGS = -Wall
-
 SRC = src
 BUILD = build
 BIN = bin
 
-# Adicionado o $(BUILD)/ast.o na lista de dependências
 TARGET = $(BIN)/compilador
 OBJS = $(BUILD)/lex.yy.o $(BUILD)/parser.tab.o $(BUILD)/main.o $(BUILD)/tabela.o $(BUILD)/ast.o
+
+COVERAGE_FLAGS = --coverage -fprofile-arcs -ftest-coverage -O0
 
 all: $(TARGET)
 
@@ -17,31 +17,57 @@ $(TARGET): $(OBJS)
 	@mkdir -p $(BIN)
 	$(CC) $(CFLAGS) $^ -o $@ -lfl
 
-# Regra para o Bison
+coverage: CFLAGS += $(COVERAGE_FLAGS)
+coverage: clean $(TARGET)
+	@echo ""
+	@echo "Compilador instrumentado para coverage. Rode:"
+	@echo "  bash tests/run_tests.sh --coverage"
+
+report:
+	@echo ""
+	@mkdir -p coverage_report
+	@lcov --capture \
+	      --directory $(BUILD) \
+	      --output-file coverage_report/coverage.info \
+	      --ignore-errors mismatch \
+	      2>/dev/null; true
+	@lcov --remove coverage_report/coverage.info \
+	      '/usr/*' '*/build/lex.yy.c' '*/build/parser.tab.c' \
+	      --output-file coverage_report/coverage_filtered.info \
+	      2>/dev/null; true
+	@echo "=================================================="
+	@echo "       COBERTURA DE LINHAS (gcov)"
+	@echo "=================================================="
+	@lcov --summary coverage_report/coverage_filtered.info 2>&1 \
+	    | grep -E "lines|functions" \
+	    | awk '{ printf "  %-12s %s\n", $$1, $$2 }'; true
+	@echo "=================================================="
+
+clean-coverage:
+	@find $(BUILD) -name "*.gcda" -delete
+	@find $(BUILD) -name "*.gcno" -delete
+	@rm -rf coverage_report
+	@echo "Arquivos de coverage removidos."
+
 $(BUILD)/parser.tab.c $(BUILD)/parser.tab.h: $(SRC)/parser.y
 	@mkdir -p $(BUILD)
 	$(YACC) -d -o $(BUILD)/parser.tab.c $(SRC)/parser.y
 
-# Regra para o Flex 
 $(BUILD)/lex.yy.c: $(SRC)/lexer.l $(BUILD)/parser.tab.h
 	@mkdir -p $(BUILD)
 	$(LEX) -o $(BUILD)/lex.yy.c $(SRC)/lexer.l
 
-# Regra genérica para objetos cujos .c estão no BUILD 
 $(BUILD)/%.o: $(BUILD)/%.c
 	$(CC) $(CFLAGS) -I$(SRC) -I$(BUILD) -c $< -o $@
 
-# Regra para compilar o TABELA.C 
 $(BUILD)/tabela.o: $(SRC)/tabela.c $(SRC)/tabela.h
 	@mkdir -p $(BUILD)
 	$(CC) $(CFLAGS) -I$(SRC) -c $(SRC)/tabela.c -o $@
 
-# NOVO: Regra para compilar o AST.C que está dentro da pasta src/ast/
 $(BUILD)/ast.o: $(SRC)/ast/ast.c $(SRC)/ast/ast.h
 	@mkdir -p $(BUILD)
 	$(CC) $(CFLAGS) -I$(SRC) -c $(SRC)/ast/ast.c -o $@
 
-# Regra para o MAIN.C (Adicionado o -I$(SRC)/ast para achar o header da árvore)
 $(BUILD)/main.o: $(SRC)/main.c $(BUILD)/parser.tab.h
 	@mkdir -p $(BUILD)
 	$(CC) $(CFLAGS) -I$(SRC) -I$(SRC)/ast -I$(BUILD) -c $(SRC)/main.c -o $@

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,130 @@
+# Testes — Compilador C→Python
+
+## Estrutura
+
+```
+tests/
+├── teste.c          ← arquivo de teste manual (uso livre durante desenvolvimento)
+├── saida.py         ← saída gerada pelo compilador
+├── run_tests.sh     ← script principal de testes
+└── casos/           ← casos de teste permanentes (suite de regressão)
+    ├── basico.c
+    ├── redeclaracao_erro.c
+    └── var_nao_declarada_erro.c
+```
+
+---
+
+## Como usar
+
+### Uso diário
+```bash
+make clean && make
+bash tests/run_tests.sh
+```
+
+### Com cobertura completa de linhas
+```bash
+bash tests/run_tests.sh --coverage
+```
+
+---
+
+## Pré-requisito para coverage
+
+```bash
+sudo apt install lcov
+```
+
+> `gcov` já vem junto com o `gcc`, não precisa instalar separado.
+
+---
+
+## Saída esperada
+
+### Modo normal (`bash tests/run_tests.sh`)
+```
+Léxico:           OK
+Sintático:        OK
+Semântico:        OK
+TUDO OK!
+
+── Cobertura de Casos ──────────────────────
+  ✓ PASS  basico.c
+  ✓ PASS  [esperava erro] redeclaracao_erro.c
+  ✓ PASS  [esperava erro] var_nao_declarada_erro.c
+────────────────────────────────────────────
+  Casos:    3 total  |  3 passou  |  0 falhou
+  Cobertura de casos: 100,0%
+```
+
+### Modo coverage (`bash tests/run_tests.sh --coverage`)
+```
+RESUMO DE COBERTURA
+
+  Casos de Teste
+  ├─ Total:   4
+  ├─ Passou:  4
+  ├─ Falhou:  0
+  └─ Cobertura de casos: 100,0%
+
+  ==================================================
+       COBERTURA DE LINHAS (gcov)
+  ==================================================
+    lines.......: 55.8%
+    functions...: 68.3%
+  ==================================================
+```
+
+---
+
+## Comandos do Makefile
+
+| Comando | O que faz |
+|---|---|
+| `make` | Build normal do compilador |
+| `make clean` | Remove build e binário |
+| `make coverage` | Recompila com instrumentação gcov |
+| `make report` | Gera relatório de cobertura de linhas |
+| `make clean-coverage` | Remove só os arquivos gcov |
+
+---
+
+## Como adicionar novos casos de teste
+
+Crie arquivos `.c` em `tests/casos/` seguindo a convenção:
+
+| Nome do arquivo | Tipo | O teste passa quando... |
+|---|---|---|
+| `basico.c`, `loops.c` | Positivo | Compilador aceita sem erros |
+| `redeclaracao_erro.c` | Negativo | Compilador **rejeita** com erro |
+| `tipo_invalido_erro.c` | Negativo | Compilador **rejeita** com erro |
+
+> Arquivos com `_erro` ou `_fail` no nome são tratados como **casos negativos**.
+
+### Exemplo — caso positivo (`tests/casos/loops.c`)
+```c
+int main() {
+    int i = 0;
+    while (i < 10) {
+        i += 1;
+    }
+    return 0;
+}
+```
+
+### Exemplo — caso negativo (`tests/casos/uso_antes_declarar_erro.c`)
+```c
+int main() {
+    x = 5;
+    return 0;
+}
+```
+
+---
+
+## Observações
+
+- O `tests/teste.c` é para experimentos durante o desenvolvimento — edite, apague e reescreva à vontade
+- A pasta `coverage_report/` é gerada localmente e está no `.gitignore` — não sobe para o repositório
+- Os casos em `tests/casos/` são permanentes — garantem que o que funcionava ontem ainda funciona hoje

--- a/tests/casos/basico.c
+++ b/tests/casos/basico.c
@@ -1,0 +1,8 @@
+int main() {
+    int x = 10;
+    int y = 20;
+    int z = x + y;
+    float f = 3;
+    char c = 'a';
+    return 0;
+}

--- a/tests/casos/redeclaracao_erro.c
+++ b/tests/casos/redeclaracao_erro.c
@@ -1,0 +1,8 @@
+// Caso negativo: redeclaração de variável no mesmo escopo
+// Esperado: Erro Semantico — redeclaração
+
+int main() {
+    int x = 1;
+    int x = 2;
+    return 0;
+}

--- a/tests/casos/var_nao_declarada_erro.c
+++ b/tests/casos/var_nao_declarada_erro.c
@@ -1,0 +1,7 @@
+// Caso negativo: uso de variável não declarada
+// Esperado: Erro Semantico — variável não declarada
+
+int main() {
+    x = 10;
+    return 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,49 +1,259 @@
 #!/bin/bash
+# =================================================================
+#  run_tests.sh — Executa testes e exibe cobertura de casos
+#
+#  Uso normal:        bash tests/run_tests.sh
+#  Com coverage:      bash tests/run_tests.sh --coverage
+#
+#  Modo --coverage:
+#    Recompila com gcov, roda todos os cenários da pasta
+#    tests/casos/ e ao final exibe % de linhas cobertas.
+# =================================================================
 
-# Cores
+# ---- Cores ----
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
 NC='\033[0m'
 
+# ---- Caminhos ----
 INPUT="tests/teste.c"
 OUTPUT="tests/saida.py"
 COMPILADOR="./bin/compilador"
+CASOS_DIR="tests/casos"
+MODO_COVERAGE=0
 
-echo -e "${YELLOW}Verificando arquivo: $INPUT${NC}"
-echo "------------------------------------------"
-
-
-$COMPILADOR "$INPUT" > "$OUTPUT" 2> tmp_erros.txt
-STATUS=$? 
-cat tmp_erros.txt
-
-ERROS=$(cat tmp_erros.txt)
-
-# 1. TESTE LÉXICO E SINTÁTICO
-if [[ "$ERROS" == *"Erro sintatico"* ]]; then
-    echo -e "Léxico/Sintático: ${RED}FALHOU${NC}"
-    echo "$ERROS"
-    rm -f "$OUTPUT" 
-    exit 1
-else
-    echo -e "Léxico:           ${GREEN}OK${NC}" 
-    echo -e "Sintático:        ${GREEN}OK${NC}"
+# ---- Flag --coverage ----
+if [[ "$1" == "--coverage" ]]; then
+    MODO_COVERAGE=1
 fi
 
-# 2. TESTE SEMÂNTICO
-if [[ "$ERROS" == *"Erro Semantico"* ]]; then
-    echo -e "Semântico:        ${RED}FALHOU${NC}"
-    echo "$ERROS"
-    rm -f "$OUTPUT"
-    exit 1
-else
-    echo -e "Semântico:        ${GREEN}OK${NC}"
+# =================================================================
+#  FUNÇÃO: rodar um único arquivo de teste
+#  $1 = caminho do .c a testar
+#  $2 = descrição (opcional)
+#  Retorna 0 se passou, 1 se falhou
+# =================================================================
+rodar_teste() {
+    local arquivo="$1"
+    local descricao="${2:-$(basename "$arquivo")}"
+
+    local saida_tmp=$(mktemp /tmp/saida_XXXXXX.py)
+    local erros_tmp=$(mktemp /tmp/erros_XXXXXX.txt)
+
+    $COMPILADOR "$arquivo" > "$saida_tmp" 2> "$erros_tmp"
+    local status=$?
+    local erros
+    erros=$(cat "$erros_tmp")
+
+    rm -f "$saida_tmp" "$erros_tmp"
+
+    # Verifica se o arquivo esperava ERRO (nome contém "_erro" ou "_fail")
+    local espera_erro=0
+    if [[ "$arquivo" == *"_erro"* ]] || [[ "$arquivo" == *"_fail"* ]]; then
+        espera_erro=1
+    fi
+
+    if [[ $espera_erro -eq 1 ]]; then
+        # Caso negativo: esperamos que o compilador rejeite
+        if [[ "$erros" == *"Erro"* ]] || [[ $status -ne 0 ]]; then
+            echo -e "  ${GREEN}✓ PASS${NC}  [esperava erro] $descricao"
+            return 0
+        else
+            echo -e "  ${RED}✗ FAIL${NC}  [esperava erro, mas passou] $descricao"
+            return 1
+        fi
+    else
+        # Caso positivo: esperamos compilação sem erros
+        if [[ "$erros" == *"Erro sintatico"* ]]; then
+            echo -e "  ${RED}✗ FAIL${NC}  [erro léxico/sintático] $descricao"
+            [[ $MODO_COVERAGE -eq 1 ]] && echo "         $erros"
+            return 1
+        elif [[ "$erros" == *"Erro Semantico"* ]]; then
+            echo -e "  ${RED}✗ FAIL${NC}  [erro semântico] $descricao"
+            [[ $MODO_COVERAGE -eq 1 ]] && echo "         $erros"
+            return 1
+        else
+            echo -e "  ${GREEN}✓ PASS${NC}  $descricao"
+            return 0
+        fi
+    fi
+}
+
+# =================================================================
+#  MODO NORMAL — comportamento original + resumo de casos
+# =================================================================
+if [[ $MODO_COVERAGE -eq 0 ]]; then
+
+    echo -e "${YELLOW}Verificando arquivo: $INPUT${NC}"
+    echo "------------------------------------------"
+
+    $COMPILADOR "$INPUT" > "$OUTPUT" 2> tmp_erros.txt
+    STATUS=$?
+    cat tmp_erros.txt
+    ERROS=$(cat tmp_erros.txt)
+
+    # 1. TESTE LÉXICO E SINTÁTICO
+    if [[ "$ERROS" == *"Erro sintatico"* ]]; then
+        echo -e "Léxico/Sintático: ${RED}FALHOU${NC}"
+        rm -f "$OUTPUT"
+        rm -f tmp_erros.txt
+        exit 1
+    else
+        echo -e "Léxico:           ${GREEN}OK${NC}"
+        echo -e "Sintático:        ${GREEN}OK${NC}"
+    fi
+
+    # 2. TESTE SEMÂNTICO
+    if [[ "$ERROS" == *"Erro Semantico"* ]]; then
+        echo -e "Semântico:        ${RED}FALHOU${NC}"
+        rm -f "$OUTPUT"
+        rm -f tmp_erros.txt
+        exit 1
+    else
+        echo -e "Semântico:        ${GREEN}OK${NC}"
+    fi
+
+    echo "===================================="
+    echo -e "${GREEN}TUDO OK!${NC}"
+    echo -e "Arquivo ${YELLOW}'$OUTPUT'${NC} criado com sucesso."
+
+    # ---- Resumo de casos (se pasta tests/casos/ existir) ----
+    if [[ -d "$CASOS_DIR" ]]; then
+        TOTAL=0
+        PASSOU=0
+        FALHOU=0
+
+        echo ""
+        echo -e "${CYAN}${BOLD}── Cobertura de Casos ──────────────────────${NC}"
+
+        for f in "$CASOS_DIR"/*.c; do
+            [[ -f "$f" ]] || continue
+            TOTAL=$((TOTAL + 1))
+            if rodar_teste "$f"; then
+                PASSOU=$((PASSOU + 1))
+            else
+                FALHOU=$((FALHOU + 1))
+            fi
+        done
+
+        if [[ $TOTAL -gt 0 ]]; then
+            PCT=$(awk "BEGIN { printf \"%.1f\", ($PASSOU/$TOTAL)*100 }")
+            echo -e "${CYAN}────────────────────────────────────────────${NC}"
+            echo -e "  Casos:    $TOTAL total  |  ${GREEN}$PASSOU passou${NC}  |  ${RED}$FALHOU falhou${NC}"
+            echo -e "  Cobertura de casos: ${BOLD}${PCT}%${NC}"
+            echo -e "${CYAN}────────────────────────────────────────────${NC}"
+        fi
+    fi
+
+    rm -f tmp_erros.txt
+    exit 0
 fi
 
-echo ""====================================""
-echo -e "${GREEN}TUDO OK!${NC}"
-echo -e "Arquivo ${YELLOW}'$OUTPUT'${NC} criado com sucesso."
+# =================================================================
+#  MODO --coverage — gcov + cobertura de casos
+# =================================================================
+echo -e "${CYAN}${BOLD}"
+echo "╔══════════════════════════════════════════╗"
+echo "║     MODO COVERAGE ATIVADO                ║"
+echo "╚══════════════════════════════════════════╝"
+echo -e "${NC}"
 
-# Limpa o lixo
-rm -f tmp_erros.txt 
+# Recompila com flags de cobertura
+echo -e "${YELLOW}[1/4] Recompilando com gcov...${NC}"
+make coverage --no-print-directory
+if [[ $? -ne 0 ]]; then
+    echo -e "${RED}Falha na compilação. Abortando.${NC}"
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}"
+
+# Cria pasta de casos se não existir
+mkdir -p "$CASOS_DIR"
+
+# Verifica se existem casos
+CASOS=("$CASOS_DIR"/*.c)
+if [[ ! -f "${CASOS[0]}" ]]; then
+    echo ""
+    echo -e "${YELLOW}Nenhum arquivo em tests/casos/ encontrado.${NC}"
+    echo "Crie arquivos .c lá para cobertura automática."
+    echo "Dica: arquivos com '_erro' no nome são testados como casos negativos."
+    echo ""
+    echo "Rodando apenas o teste.c padrão..."
+    rodar_teste "$INPUT" "teste.c (padrão)"
+    echo ""
+fi
+
+# ---- Roda todos os casos ----
+echo -e "${YELLOW}[2/4] Rodando casos de teste...${NC}"
+echo ""
+
+TOTAL=0
+PASSOU=0
+FALHOU=0
+FALHAS=()
+
+for f in "$CASOS_DIR"/*.c; do
+    [[ -f "$f" ]] || continue
+    TOTAL=$((TOTAL + 1))
+    nome=$(basename "$f")
+    if rodar_teste "$f" "$nome"; then
+        PASSOU=$((PASSOU + 1))
+    else
+        FALHOU=$((FALHOU + 1))
+        FALHAS+=("$nome")
+    fi
+done
+
+# Roda também o teste.c principal se existir
+if [[ -f "$INPUT" ]]; then
+    TOTAL=$((TOTAL + 1))
+    if rodar_teste "$INPUT" "teste.c (padrão)"; then
+        PASSOU=$((PASSOU + 1))
+    else
+        FALHOU=$((FALHOU + 1))
+        FALHAS+=("teste.c")
+    fi
+fi
+
+# ---- Gera relatório gcov ----
+echo ""
+echo -e "${YELLOW}[3/4] Gerando relatório gcov/lcov...${NC}"
+make report --no-print-directory
+REPORT_STATUS=$?
+
+# ---- Resumo final ----
+echo ""
+echo -e "${CYAN}${BOLD}"
+echo "╔══════════════════════════════════════════╗"
+echo "║           RESUMO DE COBERTURA            ║"
+echo "╚══════════════════════════════════════════╝"
+echo -e "${NC}"
+
+if [[ $TOTAL -gt 0 ]]; then
+    PCT_CASOS=$(awk "BEGIN { printf \"%.1f\", ($PASSOU/$TOTAL)*100 }")
+    echo -e "  ${BOLD}Casos de Teste${NC}"
+    echo -e "  ├─ Total:   $TOTAL"
+    echo -e "  ├─ ${GREEN}Passou:  $PASSOU${NC}"
+    echo -e "  ├─ ${RED}Falhou:  $FALHOU${NC}"
+    echo -e "  └─ Cobertura de casos: ${BOLD}${PCT_CASOS}%${NC}"
+
+    if [[ ${#FALHAS[@]} -gt 0 ]]; then
+        echo ""
+        echo -e "  ${RED}Casos que falharam:${NC}"
+        for f in "${FALHAS[@]}"; do
+            echo -e "    ${RED}✗${NC} $f"
+        done
+    fi
+fi
+
+echo ""
+if [[ $REPORT_STATUS -ne 0 ]]; then
+    echo -e "  ${YELLOW}Aviso: lcov não encontrado. Instale com:${NC}"
+    echo -e "  ${YELLOW}  sudo apt install lcov${NC}"
+fi
+
+echo ""
+echo -e "${CYAN}════════════════════════════════════════════${NC}"


### PR DESCRIPTION
## Descrição

Implementa um sistema de cobertura de testes em duas camadas para o compilador C→Python, integrado ao fluxo existente de `make` e `run_tests.sh`.

---

## O que foi alterado

| Arquivo | Alteração |
|---|---|
| `Makefile` | Adicionados alvos `coverage`, `report` e `clean-coverage` |
| `tests/run_tests.sh` | Adicionado modo `--coverage` com resumo de casos |
| `tests/casos/` | Nova pasta com casos de teste permanentes |
| `.gitignore` | Adicionado `coverage_report/` |

---

## Como funciona

### Camada 1 — Cobertura de Casos
Mede quantos arquivos de `tests/casos/` passaram ou falharam.

**Convenção de nomes:**
- `basico.c`, `loops.c` → positivo: deve compilar sem erros
- `redeclaracao_erro.c`, `tipo_invalido_erro.c` → negativo: deve gerar erro semântico

### Camada 2 — Cobertura de Linhas (gcov)
Mede quais linhas do código C do compilador foram executadas durante os testes.

---

## Pré-requisitos

Instalar **uma única vez** na máquina:

```bash
sudo apt install lcov
```

> `gcov` já vem junto com o `gcc`, não precisa instalar separado.

---

## Como usar

**Uso diário (sem coverage):**
```bash
make clean && make
bash tests/run_tests.sh
```

**Com cobertura completa:**
```bash
bash tests/run_tests.sh --coverage
```

---

## Execução

### 1. Build com instrumentação gcov

<img width="1298" height="588" alt="image" src="https://github.com/user-attachments/assets/3305ac64-8df6-4e91-8fe6-c79af354e5b2" />


### 2. Resultado dos casos de teste

<img width="1303" height="692" alt="image" src="https://github.com/user-attachments/assets/3ea4fe64-6302-40db-8e28-97a07379975e" />



### 3. Resumo final de cobertura

<img width="1303" height="567" alt="image" src="https://github.com/user-attachments/assets/b2a48125-e586-414c-b555-8e190a1df765" />

---

## Resultados atuais

| Métrica | Valor |
|---|---|
| Cobertura de casos | **100%** (4/4) |
| Cobertura de linhas | **55,8%** (431/773) |
| Cobertura de funções | **68,3%** (28/41) |

---

## Observações

- A pasta `coverage_report/` é gerada localmente e está no `.gitignore`
- Para adicionar novos casos, basta criar arquivos `.c` em `tests/casos/`
- Arquivos com `_erro` ou `_fail` no nome são tratados como casos negativos