### PR TITLE
[Feat]:. Mapeia else if do C para elif do Python

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -305,23 +305,43 @@ void generate_python(ASTNode* node, int indent_level) {
             break;
 
         case NODE_IF: {
-                indent_print(indent_level);
-                printf("if ");
-                generate_python(node->left, 0);
-                printf(":\n");
 
-                ASTNode* branches = node->right;
-                if (branches) {
-                    generate_python(branches->left, indent_level + 1);
+            indent_print(indent_level);
+            printf("if ");
+            generate_python(node->left, 0);
+            printf(":\n");
 
-                    if (branches->right) {
+            ASTNode* branches = node->right;
+            if (branches) {
+                generate_python(branches->left, indent_level + 1);
+
+                ASTNode* else_branch = branches->right;
+                while (else_branch != NULL) {
+                    if (else_branch->type == NODE_IF) {
+                        /* else if -> elif */
+                        indent_print(indent_level);
+                        printf("elif ");
+                        generate_python(else_branch->left, 0);
+                        printf(":\n");
+
+                        ASTNode* elif_branches = else_branch->right;
+                        if (elif_branches) {
+                            generate_python(elif_branches->left, indent_level + 1);
+                            else_branch = elif_branches->right;
+                        } else {
+                            else_branch = NULL;
+                        }
+                    } else {
+                        
                         indent_print(indent_level);
                         printf("else:\n");
-                        generate_python(branches->right, indent_level + 1);
+                        generate_python(else_branch, indent_level + 1);
+                        else_branch = NULL;
                     }
                 }
-                break;
             }
+            break;
+        }
 
         case NODE_ARRAY_DECL:
             indent_print(indent_level);

--- a/tests/casos/if_apenas_ok.c
+++ b/tests/casos/if_apenas_ok.c
@@ -1,0 +1,7 @@
+int main() {
+    int x = 5;
+    if (x > 0) {
+        int y = 1;
+    }
+    return 0;
+}

--- a/tests/casos/if_elif_else_ok.c
+++ b/tests/casos/if_elif_else_ok.c
@@ -1,0 +1,11 @@
+int main() {
+    int x = 10;
+    if (x > 10) {
+        int y = 1;
+    } else if (x == 10) {
+        int y = 2;
+    } else {
+        int y = 3;
+    }
+    return 0;
+}

--- a/tests/casos/if_else_ok.c
+++ b/tests/casos/if_else_ok.c
@@ -1,0 +1,9 @@
+int main() {
+    int x = 5;
+    if (x > 10) {
+        int y = 1;
+    } else {
+        int y = 2;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Descrição

Implementa o mapeamento correto de estruturas condicionais do C para Python, traduzindo `else if` para `elif` em vez de gerar `else:\n    if` aninhado.

---

## O que foi alterado

| Arquivo | Alteração |
|---|---|
| `src/ast/ast.c` | Atualizado `case NODE_IF` no `generate_python` para detectar `else if` e gerar `elif` |
| `tests/casos/if_elif_else_ok.c` | Novo caso de teste: if + elif + else completo |
| `tests/casos/if_apenas_ok.c` | Novo caso de teste: if sem else |
| `tests/casos/if_else_ok.c` | Novo caso de teste: if + else sem elif |

---

## Como funciona

Antes, qualquer `else` gerava `else:\n    if`, criando indentação desnecessária. Agora, ao encontrar um `else`, o gerador verifica se o nó é um `NODE_IF` — se sim, gera `elif`; se não, gera `else` normalmente.

---

## Exemplos de saída

### Antes
```python
if (x > 10):
    y = 1
else:
    if (x == 10):
        y = 2
    else:
        y = 3
```

### Depois
```python
if (x > 10):
    y = 1
elif (x == 10):
    y = 2
else:
    y = 3
```

---

## Prints da execução

### 1. Saída Python com elif gerado corretamente

<img width="602" height="384" alt="image" src="https://github.com/user-attachments/assets/56641bd6-4739-471f-b8eb-177ac666613e" />

### 2. Cobertura de casos passando

<img width="683" height="509" alt="image" src="https://github.com/user-attachments/assets/9a7e04c6-0594-406a-97a5-e6dac7d51b86" />
<img width="682" height="580" alt="image" src="https://github.com/user-attachments/assets/f202ec47-70d6-4f80-aeba-db51d08ae224" />
<img width="568" height="535" alt="image" src="https://github.com/user-attachments/assets/438be08f-4e6b-45ec-88cd-5d930dfbac22" />


---

## Cobertura de testes

| Caso | Tipo | Cenário |
|---|---|---|
| `if_elif_else_ok.c` | Positivo | if + elif + else completo |
| `if_apenas_ok.c` | Positivo | if sem else |
| `if_else_ok.c` | Positivo | if + else sem elif |