### PR TITLE
fix: aviso promocao de tipo

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -265,6 +265,7 @@ atribuicao:
                 $1);
             exit(1);
         }
+        checar_atribuicao_parser($1, $3, yylineno);
         $$ = create_assign_node($1, "=", $3);
     }
 
@@ -274,6 +275,7 @@ atribuicao:
             fprintf(stderr, "Erro Semantico na linha %d: Variavel '%s' nao declarada.\n", yylineno, $1);
             exit(1);
         }
+        checar_atribuicao_parser($1, $3, yylineno);
         $$ = create_assign_node($1, "+=", $3);
     }
     | ID SUB_ATRIB expressao PONTO_VIRGULA { 
@@ -281,6 +283,7 @@ atribuicao:
             fprintf(stderr, "Erro Semantico na linha %d: Variavel '%s' nao declarada.\n", yylineno, $1);
             exit(1);
         }
+        checar_atribuicao_parser($1, $3, yylineno);
         $$ = create_assign_node($1, "-=", $3); 
     }
     | ID MULT_ATRIB expressao PONTO_VIRGULA {
@@ -288,6 +291,7 @@ atribuicao:
             fprintf(stderr, "Erro Semantico na linha %d: Variavel '%s' nao declarada.\n", yylineno, $1);
             exit(1);
         }
+        checar_atribuicao_parser($1, $3, yylineno);
         $$ = create_assign_node($1, "*=", $3);
     }
     | ID DIV_ATRIB expressao PONTO_VIRGULA {
@@ -295,6 +299,7 @@ atribuicao:
             fprintf(stderr, "Erro Semantico na linha %d: Variavel '%s' nao declarada.\n", yylineno, $1);
             exit(1);
         }
+        checar_atribuicao_parser($1, $3, yylineno);
         $$ = create_assign_node($1, "/=", $3);
     }
     | ID MOD_ATRIB expressao PONTO_VIRGULA {
@@ -302,6 +307,7 @@ atribuicao:
             fprintf(stderr, "Erro Semantico na linha %d: Variavel '%s' nao declarada.\n", yylineno, $1);
             exit(1);
         }
+        checar_atribuicao_parser($1, $3, yylineno);
         $$ = create_assign_node($1, "%=", $3);
     }
 

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -184,42 +184,12 @@ void analisar_semantico(ASTNode* node) {
             analisar_semantico(node->right);
             return;
         case NODE_FUNC:
-            analisar_semantico(node->right);
+            analisar_semantico(node->left);
             return;
         case NODE_BLOCK:
             analisar_semantico(node->left);
             return;
-        case NODE_VAR_DECL:
-            if (node->right != NULL) {
-                analisar_semantico(node->right);
-                const char* t_decl = node->var_type;
-                const char* t_init = inferir_tipo(node->right);
-                if (t_decl != NULL && t_init != NULL && strcmp(t_init, "invalido") != 0) {
-                    TipoRank r_decl = obter_rank(t_decl);
-                    TipoRank r_init = obter_rank(t_init);
-                    if (r_init > r_decl && r_decl != TIPO_INVALIDO)
-                        fprintf(stderr, "Aviso Semantico na linha %d: Atribuicao com possivel perda de precisao: '%s' atribuido a variavel do tipo '%s'.\n",
-                            yylineno, t_init, t_decl);
-                }
-            }
-            break;
-        case NODE_ASSIGN:
-            analisar_semantico(node->right);
-            if (node->value != NULL) {
-                Simbolo* s = buscar(node->value);
-                if (s != NULL) {
-                    const char* t_var  = s->tipo;
-                    const char* t_expr = inferir_tipo(node->right);
-                    if (t_expr != NULL && strcmp(t_expr, "invalido") != 0) {
-                        TipoRank r_var  = obter_rank(t_var);
-                        TipoRank r_expr = obter_rank(t_expr);
-                        if (r_expr > r_var && r_var != TIPO_INVALIDO)
-                            fprintf(stderr, "Aviso Semantico na linha %d: Atribuicao com possivel perda de precisao: '%s' atribuido a variavel '%s' do tipo '%s'.\n",
-                                yylineno, t_expr, node->value, t_var);
-                    }
-                }
-            }
-            break;
+        
         case NODE_BINARY_OP:
             analisar_semantico(node->left);
             analisar_semantico(node->right);
@@ -316,4 +286,22 @@ void checar_operacao_binaria_parser(const char* op,
     if (strcmp(t_esq, "invalido") == 0 || strcmp(t_dir, "invalido") == 0)
         return;
     checar_operacao_binaria(op, t_esq, t_dir, linha);
+}
+
+void checar_atribuicao_parser(char* nome, ASTNode* expr, int linha) {
+    if (nome == NULL || expr == NULL) return;
+
+    Simbolo* s = buscar(nome);
+    if (s == NULL) return;
+
+    const char* t_var  = s->tipo;
+    const char* t_expr = inferir_tipo_live(expr);
+    if (t_var == NULL || t_expr == NULL || strcmp(t_expr, "invalido") == 0)
+        return;
+
+    TipoRank r_var  = obter_rank(t_var);
+    TipoRank r_expr = obter_rank(t_expr);
+    if (r_expr > r_var && r_var != TIPO_INVALIDO)
+        fprintf(stderr, "Aviso Semantico na linha %d: Atribuicao com possivel perda de precisao: '%s' atribuido a variavel '%s' do tipo '%s'.\n",
+            linha, t_expr, nome, t_var);
 }

--- a/src/semantic.h
+++ b/src/semantic.h
@@ -23,5 +23,6 @@ const char* inferir_tipo(ASTNode* node);
 const char* promover_tipos(const char* tipo_esq, const char* tipo_dir);
 void checar_operacao_binaria(const char* op, const char* tipo_esq, const char* tipo_dir, int linha);
 void checar_operacao_binaria_parser(const char* op, ASTNode* esq, ASTNode* dir, int linha);
+void checar_atribuicao_parser(char* nome, ASTNode* expr, int linha);
 
 #endif

--- a/tests/teste.c
+++ b/tests/teste.c
@@ -1,10 +1,17 @@
 int main() {
-    int idade;
-
-    printf("Digite sua idade:");
-    scanf("%d", &idade);
-
-    printf(idade);
-
+    int x = 3.5;
+    int y;
+    y = 2.7;
+    int z = 0;
+    z += 1.9;
+    for (int i = 0; i < 3; i = i + 1.5) {
+        z = z + 1;
+    }
+    float d = 3.0;
+    y = d;
+    int w = 10;
+    w = w + 1;
+    int k;
+    k = 'a';
     return 0;
 }


### PR DESCRIPTION
## Descrição
Corrigida aviso de promoção de tipos e detecção de possíveis perdas de precisão durante a análise semântica.

---

## Vínculo com Issue
* Closes #87 

---

## Funcionalidades Implementadas

*  Verificação de atribuições em tempo de parsing para preservar informações de escopo.

---

## Alterações Realizadas

### Parser

Integração da função checar_atribuicao_parser() nas regras de:
* =
* +=
* -=
* *=
* /=
* %= 

### Semântica

Corrigida a navegação da AST em:

* NODE_FUNC
* NODE_VAR_DECL
* NODE_ASSIGN

Adicionada a função:
* checar_atribuicao_parser()

### Testes

**Antes**
<img width="655" height="872" alt="image" src="https://github.com/user-attachments/assets/2f9f08d4-573b-439c-97ff-ec9c64ccf376" />

**Depois**
<img width="871" height="909" alt="image" src="https://github.com/user-attachments/assets/cfe03125-5a7e-44e9-b3ee-49f78ccca901" />

<img width="527" height="873" alt="image" src="https://github.com/user-attachments/assets/12ef919e-e973-4e96-a7be-9856e1f12eb0" />


---

## Resultado

*  Declarações e atribuições com perda de precisão geram alerta.